### PR TITLE
fix: detect linux architecture in install script

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -1,25 +1,34 @@
 #!/bin/sh
 
-set -e  # Exit on error
+set -e
 
-# Define the download URL
-URL="https://github.com/flowscripter/example-host-application/releases/latest/download/example-host-application_Linux_x86_64.zip"
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)
+    ARCH_SUFFIX="x64"
+    ;;
+  aarch64|arm64)
+    ARCH_SUFFIX="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
 
-# Create a temporary directory
+URL="https://github.com/flowscripter/example-host-application/releases/latest/download/example-host-application_Linux_${ARCH_SUFFIX}.zip"
+
 TMP_DIR=$(mktemp -d)
 cd "$TMP_DIR"
 
-# Download and extract
 echo "Downloading example-host-application..."
 curl -fsSL "$URL" -o executable.zip
 unzip executable.zip
 
-# Install
 chmod +x example-host-application
 sudo mv example-host-application /usr/local/bin/
 
-# Clean up
 cd -
 rm -rf "$TMP_DIR"
 
-echo "✅ Installation complete! Run 'example-host-application' to get started."
+echo "Installation complete! Run 'example-host-application' to get started."


### PR DESCRIPTION
## Summary

- Adds architecture detection using `uname -m` to select between `x64` and `arm64` artifact suffixes
- Fixes the hardcoded `x86_64` suffix which did not match the actual release artifact naming
- Exits with an error message for unsupported architectures

## Test plan

- [ ] Verify install on x86_64 Linux resolves to `example-host-application_Linux_x64.zip`
- [ ] Verify install on aarch64/arm64 Linux resolves to `example-host-application_Linux_arm64.zip`
- [ ] Verify unsupported arch prints error and exits non-zero

Generated with [Claude Code](https://claude.com/claude-code)